### PR TITLE
rpm target support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ clean: clean-tests
 
 # Clean up all files, even those that you usually don't want to
 # rebuild. That is, include the dependencies living under vendor/.
-superclean: clean clean-luajit clean-ljsyscall
+distclean: clean clean-luajit clean-ljsyscall
 	rm -rf $(staging-dir)
 
-.PHONY: all clean superclean
+.PHONY: all clean distclean
 
 #
 # LuaJIT

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ binaries := tcp_rr tcp_stream dummy_test
 default: all
 
 # avoid dep geneation on clean targets
-ifneq  (,$(findstring $(MAKECMDGOALS),clean))
+# FIXME: on make 4.2 the expression evaluate uncorrectly with a full 'clean'
+# pattern is this a make bug?
+ifneq (,$(findstring $(MAKECMDGOALS),clea))
 -include $(base-objs:.o=.d)
 -include $(tcp_rr-objs:.o=.d)
 -include $(tcp_stream-objs:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,9 @@ dummy_test: $(dummy_test-objs)
 
 all: $(binaries)
 
-dist: distclean
-	mkdir rushit-$(VERSION)
-	rsync -Cavz --exclude 'rushit-$(VERSION)' . rushit-$(VERSION)
-	tar -czf $(DIST_ARCHIVES) rushit-$(VERSION)
-	rm -rf rushit-$(VERSION)
+# beware: dist and rpm target work only inside a git tree
+dist:
+	git archive --output=$(DIST_ARCHIVES) --prefix=rushit-$(VERSION)/ HEAD
 
 rpm: dist
 	mkdir -p ${RPMBUILD_TOP}/SOURCES
@@ -129,12 +127,12 @@ rpm: dist
 # exclude the dependencies living under vendor/.
 clean: clean-tests
 	rm -f *.[do] $(binaries) $(DIST_ARCHIVES)
-	rm -rf rushit-$(VERSION) rpm/
 
 # Clean up all files, even those that you usually don't want to
 # rebuild. That is, include the dependencies living under vendor/.
 distclean: clean clean-luajit clean-ljsyscall
 	rm -rf $(staging-dir)
+	rm -rf rpm/
 
 .PHONY: all clean distclean dist rpm
 

--- a/rushit.spec
+++ b/rushit.spec
@@ -1,0 +1,39 @@
+%define rushit_version 0.1
+
+Name:		rushit
+Version:	%{rushit_version}
+Release:	1%{?dist}
+Summary:	scriptable performance tool
+
+Group:		Applications/Internet
+License:	ASL 2.0
+URL:		https://github.com/jsitnicki/rushit/
+Source0:	rushit-%{version}.tar.gz
+
+BuildRequires:	libcmocka-devel
+
+%description
+rushit is a tool for performance testing highly configurable
+via lua scripts
+
+%prep
+%setup -q
+
+%build
+make %{?_smp_mflags}
+
+%install
+# rhel 'install' command does not support '-D' option properly, we need to
+# explicitly create the full paths here
+mkdir -p $RPM_BUILD_ROOT/%{_bindir}/    \
+    $RPM_BUILD_ROOT/%{_datadir}/rushit/ \
+    $RPM_BUILD_ROOT/%{_docdir}/rushit/
+install -p -t $RPM_BUILD_ROOT/%{_bindir}/ tcp_stream tcp_rr
+install -p -m 0644 -t $RPM_BUILD_ROOT/%{_datadir}/rushit/ scripts/*.lua
+install -p -m 0644 -t $RPM_BUILD_ROOT/%{_docdir}/rushit/ README.md README.neper.md
+
+%files
+%defattr(-,root,root)
+%{_bindir}/*
+%{_datadir}/rushit/*.lua
+%{_docdir}/rushit/README*


### PR DESCRIPTION
this introduces support for the 'dist' and 'rpm' targets, plus some minor fixes in the makefile.

The rpm target support is split in 2 commits, 1 introducing it and 1 to use 'git archive' to generate the tar ball, to keep track of the reasoning behind the implementation.

The copr build generated on top of this changes is available here:

https://copr.fedorainfracloud.org/coprs/pabeni/rushit/build/661666/