### PR TITLE
udp_stream: collect TX stats, too

### DIFF
--- a/udp_stream.c
+++ b/udp_stream.c
@@ -75,6 +75,10 @@ write_again:
                                 continue;
                         }
 
+                        flow->bytes_read += num_bytes;
+                        flow->transactions++;
+                        interval_collect(flow, t);
+
                         if (opts->edge_trigger)
                                 goto write_again;
                 }


### PR DESCRIPTION
On UDP flows the xmitted tput can be greater than the received
one, so collect stats on TX side, too.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>